### PR TITLE
Fix slider day display

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To deploy the web app to GitHub Pages, follow the steps below:
 * create a production build of the web app by running `yarn build`
 * switch to the main publishing branch by running `git checkout gh-pages` and
   then `git pull`
-* create a new branch by running `git checkout <branch>` and then
+* create a new branch by running `git checkout -b <branch>` and then
   `git push -u origin <branch>` (replacing `<branch>` with the name you've
   chosen to give this publishing branch)
 * run these commands in sequence in order to copy the build files into the

--- a/src/ForecastSelector.tsx
+++ b/src/ForecastSelector.tsx
@@ -76,21 +76,26 @@ class ForecastSelector extends React.Component<Props, State> {
         // Generate an array of slider marks to match the first
         // MAX_FORECAST_ENTRIES forecasts
         const marks: Mark[] = [];
+        let prevDay = 0;
         forecast.forEach((item, index) => {
             if (index < ForecastSelector.MAX_FORECAST_ENTRIES) {
                 const date = new Date(item.dt * 1000);
                 const hours = date.getHours();
+                const day = date.getDay();
+
+                // Show name of the day when the time crosses into a new day
+                const showDay = day !== prevDay;
+
                 const label = index <= 0
                     ? ""
-                    : (hours === 0
-                        ? this.dayToString(date.getDay())
-                        : "");
+                    : (showDay ? this.dayToString(day) : "");
                 const time = (hours >= 10 ? hours.toString() : "0" + hours) + ":00";
                 marks.push({
                     label: label,
                     time: time,
                     value: index
                 });
+                prevDay = day;
             }
         });
         this.setState({


### PR DESCRIPTION
Fixed display of the day of the week on the forecast selector slider.

Issue probably caused by a change in the format of the forecast data (don't assume anything about which times are returned, instead detect a day boundary by checking when the day actually changes).

A small README fix to the branch creation command is included.

Closes #20 